### PR TITLE
douyin API update

### DIFF
--- a/douyin_pro_2.py
+++ b/douyin_pro_2.py
@@ -2,6 +2,7 @@
 from contextlib import closing
 import requests, json, re, os, sys, random
 from ipaddress import ip_address
+from subprocess import Popen, PIPE
 
 class DouYin(object):
 	def __init__(self, width = 500, height = 300):
@@ -51,7 +52,11 @@ class DouYin(object):
 		dytk = _dytk_re.search(share_user.text).group(1)
 		print('签名JS下载中')
 		self.video_downloader('https://raw.githubusercontent.com/loadchange/amemv-crawler/master/fuck-byted-acrawler.js', 'fuck-byted-acrawler.js')
-		singer = os.popen('node fuck-byted-acrawler.js %s' % uid)
+		try:
+			process = Popen(['node', 'fuck-byted-acrawler.js', str(uid)], stdout=PIPE, stderr=PIPE)
+		except (OSError, IOError) as err:
+			print('请先安装 node.js: https://nodejs.org/')
+			sys.exit()
 		sign = singer.readlines()[0]
 		user_url = 'https://www.amemv.com/aweme/v1/aweme/post/?user_id=%s&max_cursor=0&count=%s&aid=1128&_signature=%s&dytk=%s' % (uid, aweme_count, sign, dytk)
 		req = requests.get(user_url, headers=self.headers)

--- a/douyin_pro_2.py
+++ b/douyin_pro_2.py
@@ -46,6 +46,11 @@ class DouYin(object):
 			uid = html['user_list'][0]['user_info']['uid']
 			nickname = html['user_list'][0]['user_info']['nickname']
 			unique_id = html['user_list'][0]['user_info']['unique_id']
+			if unique_id != user_id:
+				unique_id = html['user_list'][0]['user_info']['short_id']
+			else:
+				print('用户ID可能输入错误或无法搜索到此用户ID')
+				sys.exit()
 		share_user_url = 'https://www.amemv.com/share/user/%s' % uid
 		share_user = requests.get(share_user_url, headers=self.headers)
 		_dytk_re = re.compile(r"dytk: '(.+)'")

--- a/douyin_pro_2.py
+++ b/douyin_pro_2.py
@@ -38,17 +38,16 @@ class DouYin(object):
 		share_urls = []
 		unique_id = ''
 		device_id = str(random.randint(3, 5)) + ''.join(map(str, (random.randint(0, 9) for _ in range(10))))
-		while unique_id != user_id:
-			search_url = 'https://api.amemv.com/aweme/v1/discover/search/?cursor=0&keyword={0}&count=10&type=1&retry_type=no_retry&device_id={1}&ac=wifi&channel=xiaomi&aid=1128&app_name=aweme&version_code=162&version_name=1.6.2&device_platform=android&ssmix=a&device_type=MI+5&device_brand=Xiaomi&os_api=24&os_version=7.0&manifest_version_code=162&resolution=1080*1920&dpi=480&update_version_code=1622'.format(user_id, device_id)
-			req = requests.get(search_url, headers=self.headers)
-			html = json.loads(req.text)
-			aweme_count = 32767 # html['user_list'][0]['user_info']['aweme_count']
-			uid = html['user_list'][0]['user_info']['uid']
-			nickname = html['user_list'][0]['user_info']['nickname']
-			unique_id = html['user_list'][0]['user_info']['unique_id']
+		search_url = 'https://api.amemv.com/aweme/v1/discover/search/?cursor=0&keyword={0}&count=10&type=1&retry_type=no_retry&device_id={1}&ac=wifi&channel=xiaomi&aid=1128&app_name=aweme&version_code=162&version_name=1.6.2&device_platform=android&ssmix=a&device_type=MI+5&device_brand=Xiaomi&os_api=24&os_version=7.0&manifest_version_code=162&resolution=1080*1920&dpi=480&update_version_code=1622'.format(user_id, device_id)
+		req = requests.get(search_url, headers=self.headers)
+		html = json.loads(req.text)
+		aweme_count = 32767 # html['user_list'][0]['user_info']['aweme_count']
+		uid = html['user_list'][0]['user_info']['uid']
+		nickname = html['user_list'][0]['user_info']['nickname']
+		unique_id = html['user_list'][0]['user_info']['unique_id']
+		if unique_id != user_id:
+			unique_id = html['user_list'][0]['user_info']['short_id']
 			if unique_id != user_id:
-				unique_id = html['user_list'][0]['user_info']['short_id']
-			else:
 				print('用户ID可能输入错误或无法搜索到此用户ID')
 				sys.exit()
 		share_user_url = 'https://www.amemv.com/share/user/%s' % uid

--- a/douyin_pro_2.py
+++ b/douyin_pro_2.py
@@ -57,7 +57,7 @@ class DouYin(object):
 		except (OSError, IOError) as err:
 			print('请先安装 node.js: https://nodejs.org/')
 			sys.exit()
-		sign = singer.readlines()[0]
+		sign = process.communicate()[0].decode()
 		user_url = 'https://www.amemv.com/aweme/v1/aweme/post/?user_id=%s&max_cursor=0&count=%s&aid=1128&_signature=%s&dytk=%s' % (uid, aweme_count, sign, dytk)
 		req = requests.get(user_url, headers=self.headers)
 		html = json.loads(req.text)


### PR DESCRIPTION
#34 #35 **更新后需要安装 node.js 才能正常使用**
1. `headers` 增加 `X-Real-IP` 和 `X-Forwarded-For` 伪造访问 IP (可能没用)
2. `discover/search` 的 `device_id` 改为随机，暂时解决需要登录的限制，以后可能一定要登录才能使用
3. `aweme/post` 新增 `_signature` 和 `dytk`，`_signature` 的算法来自 [amemv-crawler](https://github.com/loadchange/amemv-crawler)，需要安装 node.js
4. 移除 `create_time`，新 API 没有此项，因此文件名改为 `share_id-share_desc` (视频ID-视频标题)
5. 提示需要安装 node.js
6. 不用 `while` 循环避免搜索 API 多次访问造成访问限制，用户ID更改后，使用原ID也可搜索