### PR TITLE
docs: fix simple typo, resopnsible -> responsible

### DIFF
--- a/2020/bilibili/xml2ass.py
+++ b/2020/bilibili/xml2ass.py
@@ -2,7 +2,7 @@
 # This file is released under General Public License version 3.
 # You should have received a copy of General Public License text alongside with
 # this program. If not, you can obtain it at http://gnu.org/copyleft/gpl.html .
-# This program comes with no warranty, the author will not be resopnsible for
+# This program comes with no warranty, the author will not be responsible for
 # any damage or problems caused by this program.
 
 import argparse

--- a/bilibili/xml2ass.py
+++ b/bilibili/xml2ass.py
@@ -2,7 +2,7 @@
 # This file is released under General Public License version 3.
 # You should have received a copy of General Public License text alongside with
 # this program. If not, you can obtain it at http://gnu.org/copyleft/gpl.html .
-# This program comes with no warranty, the author will not be resopnsible for
+# This program comes with no warranty, the author will not be responsible for
 # any damage or problems caused by this program.
 
 import argparse


### PR DESCRIPTION
There is a small typo in 2020/bilibili/xml2ass.py, bilibili/xml2ass.py.

Should read `responsible` rather than `resopnsible`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md